### PR TITLE
Add support for Tags in EIP object

### DIFF
--- a/osc/data_source_osc_eip.go
+++ b/osc/data_source_osc_eip.go
@@ -25,6 +25,7 @@ func dataSourceAwsEip() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"tags": dataSourceTagsSchema(),
 		},
 	}
 }
@@ -59,6 +60,10 @@ func dataSourceAwsEipRead(d *schema.ResourceData, meta interface{}) error {
 	d.SetId(*eip.AllocationId)
 	d.Set("id", eip.AllocationId)
 	d.Set("public_ip", eip.PublicIp)
+
+	if err := d.Set("tags", dataSourceTags(eip.Tags)); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/osc/resource_osc_eip_test.go
+++ b/osc/resource_osc_eip_test.go
@@ -77,6 +77,26 @@ func TestAccAWSEIP_basic(t *testing.T) {
 	})
 }
 
+func TestAccAWSEIP_tags(t *testing.T) {
+	var conf ec2.Address
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:      func() { testAccPreCheck(t) },
+		IDRefreshName: "aws_eip.tagged",
+		Providers:     testAccProviders,
+		CheckDestroy:  testAccCheckAWSEIPDestroy,
+		Steps: []resource.TestStep{
+			resource.TestStep{
+				Config: testAccAWSEIPTags,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAWSEIPExists("aws_eip.tagged", &conf),
+					testAccCheckAWSEIPAttributes(&conf),
+				),
+			},
+		},
+	})
+}
+
 func TestAccAWSEIP_instance(t *testing.T) {
 	var conf ec2.Address
 
@@ -298,6 +318,14 @@ func testAccCheckAWSEIPExists(n string, res *ec2.Address) resource.TestCheckFunc
 
 const testAccAWSEIPConfig = `
 resource "aws_eip" "bar" {
+}
+`
+
+const testAccAWSEIPTags = `
+resource "aws_eip" "tagged" {
+  tags {
+    Name = "eip_test"
+  }
 }
 `
 


### PR DESCRIPTION
This PR adds support for tags on EIP objects, and should fix #7 ; however it needs to be extensively tested across use-cases.